### PR TITLE
Create Invalid `prisma.$queryRawUnsafe()` invocation: Raw query faile…

### DIFF
--- a/Invalid `prisma.$queryRawUnsafe()` invocation: Raw query failed. Code: `42703`. Message: `column "undefined" does not exist`
+++ b/Invalid `prisma.$queryRawUnsafe()` invocation: Raw query failed. Code: `42703`. Message: `column "undefined" does not exist`
@@ -1,0 +1,1 @@
+Invalid `prisma.$queryRawUnsafe()` invocation: Raw query failed. Code: `42703`. Message: `column "undefined" does not exist`


### PR DESCRIPTION
…d. Code: `42703`. Message: `column "undefined" does not exist`